### PR TITLE
Update default `WEBGIS_DOCKER_SHARED_VOLUME` within .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ WEBGIS_PUBLIC_HOSTNAME=dev.g3wsuite.it
 
 # Shared volume mount (docker internal: shared-volume)
 # I suggest not to use the /tmp/ folder, /tmp/ folder is cleaned at each reboot
-WEBGIS_DOCKER_SHARED_VOLUME=/tmp/shared-volume-g3wsuite-dev
+WEBGIS_DOCKER_SHARED_VOLUME=./shared-volume
 
 # Docker internal DB
 G3WSUITE_POSTGRES_USER_LOCAL=g3wsuite


### PR DESCRIPTION
As per `.gitignore`: https://github.com/g3w-suite/g3w-suite-docker/blob/0850eded5bd5225a88266fb1b1b5fa14dda0b352/.gitignore#L7



Closes: https://github.com/g3w-suite/g3w-suite-docker/issues/50

