### PR TITLE
FIX: update TEMPLATES search paths to allow overriding of default templates

### DIFF
--- a/config/g3w-suite/settings_docker.py
+++ b/config/g3w-suite/settings_docker.py
@@ -2,6 +2,11 @@
 # Destination: /code/g3w-admin/base/settings/local_settings.py
 # Read connection parameters from environment
 import os
+from base.settings.base import TEMPLATES, BASE_DIR
+
+# Allows to load custom templates from your docker volume (eg. "./config/g3w-suite/overrides/templates:/code/templates:ro")
+# see: https://docs.djangoproject.com/en/2.2/howto/overriding-templates/
+TEMPLATES[0]['DIRS'].append(os.path.join(BASE_DIR, '../../templates'))
 
 G3WADMIN_PROJECT_APPS = []
 


### PR DESCRIPTION
Through this patch it is now possible to override templates as explained here
- https://g3w-suite.readthedocs.io/en/latest/docker.html#style-customization
- https://docs.djangoproject.com/en/2.2/howto/overriding-templates/

As per [g3w-admin@v3.4](https://github.com/g3w-suite/g3w-admin/blob/458c8bec11864ef29b9a14291231fb0543f11b77), these are the variables that are in use / changed:

```py
# https://github.com/g3w-suite/g3w-admin/blob/458c8bec11864ef29b9a14291231fb0543f11b77/g3w-admin/base/settings/base.py#L15-L16

BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
```

```py
# https://github.com/g3w-suite/g3w-admin/blob/458c8bec11864ef29b9a14291231fb0543f11b77/g3w-admin/base/settings/base.py#L99-L123

TEMPLATES = [
    {
        'BACKEND': 'django.template.backends.django.DjangoTemplates',
        'DIRS': [os.path.join(BASE_DIR, '../templates')],
        'OPTIONS': {
            'context_processors': [
                'django.template.context_processors.debug',
                'django.template.context_processors.request',
                'django.contrib.auth.context_processors.auth',
                'django.contrib.messages.context_processors.messages',
                'django.template.context_processors.media',
                'base.context_processors.global_settings'
            ],
            'loaders': [
                    'django.template.loaders.filesystem.Loader',
                    'django.template.loaders.app_directories.Loader'
                    #('django.template.loaders.cached.Loader', [
                    #    'django.template.loaders.filesystem.Loader',
                    #    'django.template.loaders.app_directories.Loader'
                    #]),
            ]
        },

    },
]
```