### PR TITLE
Disable auto-restart for `docker-compose.dev` services

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_USER=${G3WSUITE_POSTGRES_USER_LOCAL}
       - POSTGRES_PASS=${G3WSUITE_POSTGRES_PASS}
       - ALLOW_IP_RANGE=0.0.0.0/0
-    restart: on-failure
+    restart: "no"
     logging:
       driver: "json-file"
       options:
@@ -56,7 +56,7 @@ services:
       - "8000"
     ports:
       - "8000:8000"
-    restart: always
+    restart: "no"
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Set the following to allow you to check for errors during development:

```yml
restart: "no"
```