### PR TITLE
Add `.gitattributes` file (enforce `LF` endings)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto detect text files and perform LF normalization,
+# when the file has been committed with CRLF, no conversion is done.
+* text=auto 


### PR DESCRIPTION
Add `* text=auto` in order to prevent `LF` --> `CRLF` conversion on Windows OS (ref: [gitattributes documentation](https://git-scm.com/docs/gitattributes))

Closes: https://github.com/g3w-suite/g3w-suite-docker/issues/69