### PR TITLE
Remove `DEV` environment variable check within `/scripts/docker-entrypoint.sh`

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -12,12 +12,6 @@ export QGIS_SERVER_PARALLEL_RENDERING=1
 # Start
 cd /code/g3w-admin
 
-# When building in dev env you might want a clean build each time.
-if [[ -z "${DEV}" ]]; then
-  rm -rf /shared-volume/build_done
-fi
-
-
 # Activate the front end app settings
 
 if [[ "${FRONTEND}" =~ [Tt][Rr][Uu][Ee] ]] ; then


### PR DESCRIPTION
Remove `DEV` environment variable check within `/scripts/docker-entrypoint.sh` as it doesn't appear to be in use within any of the compose files.

Closes: https://github.com/g3w-suite/g3w-suite-docker/issues/63