### PR TITLE
Update Dockerfile comments

### DIFF
--- a/.github/workflows/build_and_push_deps_ltr.yml
+++ b/.github/workflows/build_and_push_deps_ltr.yml
@@ -1,4 +1,8 @@
-name: CI to Docker hub for dependencies image.
+##
+# DOCKER BUILD: Dockerfile.g3wsuite-deps.ltr.dockerfile
+##
+
+name: Build dependencies
 
 on:
   push:

--- a/.github/workflows/build_and_push_main_image.yml
+++ b/.github/workflows/build_and_push_main_image.yml
@@ -1,4 +1,8 @@
-name: CI to Docker hub for main G3W-SUITE image.
+##
+# DOCKER BUILD: Dockerfile.g3wsuite.dockerfile
+##
+
+name: Build G3W-SUITE image
 
 on:
   push:

--- a/Dockerfile.g3wsuite-deps.dockerfile
+++ b/Dockerfile.g3wsuite-deps.dockerfile
@@ -1,9 +1,20 @@
+##
+# DOCKER IMAGE: https://hub.docker.com/r/g3wsuite/g3w-suite-deps
+#
+# This image extends UBUNTU and ships latest QGIS version
+##
+
 FROM ubuntu:jammy
-# This image is available as g3wsuite/g3w-suite-deps:latest
-LABEL maintainer="Gis3w" Description="This image is used to prepare build requirements for g3w-suite docker images" Vendor="Gis3w" Version="1.2"
+
+LABEL maintainer="Gis3w" \
+      Description="Image used to prepare build requirements for g3w-suite docker images" \
+      Vendor="Gis3w" \
+      Version="1.2"
 
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN chown root:root /tmp && chmod ugo+rwXt /tmp
+
 RUN apt-get update && apt install -y \
     libxml2-dev \
     libxslt-dev \
@@ -23,7 +34,8 @@ RUN apt-get update && apt install -y \
     xvfb
 
 # PyQGIS 3.28
-RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import &&  \
+RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | \
+    gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import && \
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg && \
     echo "deb [arch=amd64] https://qgis.org/ubuntu jammy main" >> /etc/apt/sources.list && \
     apt update && apt install -y python3-qgis qgis-server
@@ -31,8 +43,9 @@ RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-k
 # Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
-    tee /etc/apt/sources.list.d/yarn.list &&  \
+    tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt install -y yarn
 
 RUN mkdir /code
+
 WORKDIR /code

--- a/Dockerfile.g3wsuite-deps.ltr.dockerfile
+++ b/Dockerfile.g3wsuite-deps.ltr.dockerfile
@@ -1,9 +1,20 @@
+##
+# DOCKER IMAGE: https://hub.docker.com/r/g3wsuite/g3w-suite-deps:latest-ltr
+#
+# This image extends UBUNTU and ships latest QGIS LTR version
+##
+
 FROM ubuntu:jammy
-# This image is available as g3wsuite/g3w-suite-deps:latest-ltr
-LABEL maintainer="Gis3w" Description="This image is used to prepare build requirements for g3w-suite docker images" Vendor="Gis3w" Version="dev"
+
+LABEL maintainer="Gis3w" \
+      Description="Image used to prepare build requirements for g3w-suite docker images" \
+      Vendor="Gis3w" \
+      Version="dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN chown root:root /tmp && chmod ugo+rwXt /tmp
+
 RUN apt-get update && apt install -y \
     libxml2-dev \
     libxslt-dev \
@@ -23,7 +34,8 @@ RUN apt-get update && apt install -y \
     xvfb
 
 # PyQGIS 3.22
-RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import &&  \
+RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | \
+    gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import && \
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg && \
     echo "deb [arch=amd64] https://qgis.org/ubuntu-ltr jammy main" >> /etc/apt/sources.list && \
     apt update && apt install -y python3-qgis qgis-server
@@ -31,8 +43,9 @@ RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-k
 # Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
-    tee /etc/apt/sources.list.d/yarn.list &&  \
+    tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt install -y yarn
 
 RUN mkdir /code
+
 WORKDIR /code

--- a/Dockerfile.g3wsuite-deps.ltr.mssql.dockerfile
+++ b/Dockerfile.g3wsuite-deps.ltr.mssql.dockerfile
@@ -1,10 +1,22 @@
+##
+# DOCKER IMAGE: https://hub.docker.com/r/g3wsuite/g3w-suite-deps:ltr-mssql
+#
+# This image extends UBUNTU and ships the MSSQL ODBC driver,
+# by using this you agree to the additional END USER LICENSE
+# AGREEMENT FOR THE MICROSOFT SOFTWARE (see: ACCEPT_EULA=Y)
+##
+
 FROM ubuntu:jammy
-# This image is available as g3wsuite/g3w-suite-deps:ltr-mssql
-# This image contain MSSql odbc driver.
-LABEL maintainer="Gis3w" Description="This image is used to prepare build requirements for g3w-suite docker images" Vendor="Gis3w" Version="dev"
+
+LABEL maintainer="Gis3w" \
+      Description="Image used to prepare build requirements for g3w-suite docker images" \
+      Vendor="Gis3w" \
+      Version="dev"
 
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN chown root:root /tmp && chmod ugo+rwXt /tmp
+
 RUN apt-get update && apt install -y \
     libxml2-dev \
     libxslt-dev \
@@ -27,21 +39,21 @@ RUN apt-get update && apt install -y \
     xvfb
 
 # PyQGIS 3.22
-RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import &&  \
+RUN wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | \
+    gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import && \
     chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg && \
     echo "deb [arch=amd64] https://qgis.org/ubuntu-ltr jammy main" >> /etc/apt/sources.list && \
     apt update && apt install -y python3-qgis qgis-server
 
 # MSSQL
-# ACCEPT_EULA=Y END-USER LICENSE AGREEMENT FOR MICROSOFT SOFTWARE
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add &&  \
-    echo "deb https://packages.microsoft.com/ubuntu/22.04/prod jammy main" >> /etc/apt/sources.list &&  \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add && \
+    echo "deb https://packages.microsoft.com/ubuntu/22.04/prod jammy main" >> /etc/apt/sources.list && \
     apt update && ACCEPT_EULA=Y apt install -y msodbcsql18 mssql-tools
 
 # Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
-    tee /etc/apt/sources.list.d/yarn.list &&  \
+    tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt install -y yarn
 
 RUN mkdir /code

--- a/Dockerfile.g3wsuite.dockerfile
+++ b/Dockerfile.g3wsuite.dockerfile
@@ -1,19 +1,34 @@
+##
+# DOCKER IMAGE: https://hub.docker.com/r/g3wsuite/g3w-suite-dev
+#
+# This image extends G3W-SUITE LTR (UBUNTU + QGIS LTR) for development purposes 
+##
+
 FROM g3wsuite/g3w-suite-deps-ltr:dev
 
-LABEL maintainer="Gis3W" Description="This image is used to install python requirements and code for g3w-suite deployment" Vendor="Gis3W" Version="1.0"
+LABEL maintainer="Gis3W" \
+      Description="Image used to install python requirements and code for g3w-suite deployment" \
+      Vendor="Gis3W" \
+      Version="1.0"
+
+##
 # Based on main CI Docker from  g3w-suite, checkout code + caching,
 # custom settings file
+##
 RUN apt update && apt install git -y
 
-# git branch of g3w-admin to checkout.
+##
+# G3W-ADMIN git branch to checkout.
 # Defaults to `dev` but can be set to another branch name to build
 # a particular suite version
+##
 ARG G3W_SUITE_BRANCH
 
 # Override settings
 ADD requirements_rl.txt /requirements_rl.txt
 
 ADD scripts /scripts
+
 RUN chmod +x /scripts/*.sh
 
 RUN /scripts/setup.sh \

--- a/Dockerfile.postgis.dockerfile
+++ b/Dockerfile.postgis.dockerfile
@@ -1,3 +1,12 @@
+##
+# DOCKER IMAGE: https://hub.docker.com/r/g3wsuite/postgis
+# 
+# This image extends KARTOZA POSTGISS (DEBIAN + POSTGIS LTR) for development purposes 
+##
+
 FROM kartoza/postgis:11.0-2.5
-LABEL maintainer="Gis3W" Description="Fix DB restart"
+
+LABEL maintainer="Gis3W" \
+      Description="Fix DB restart"
+
 ADD setup-database.sh /

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # G3W-SUITE WebGIS
 
-[![CI to Docker hub for main G3W-SUITE image.](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_main_image.yml/badge.svg)](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_main_image.yml)
-[![CI to Docker hub for dependencies image.](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_deps_ltr.yml/badge.svg)](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_deps_ltr.yml)
+[![Build G3W-SUITE image](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_main_image.yml/badge.svg)](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_main_image.yml)
+[![Build dependencies](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_deps_ltr.yml/badge.svg)](https://github.com/g3w-suite/g3w-suite-docker/actions/workflows/build_and_push_deps_ltr.yml)
 
 This repository contains scripts and recipes for deploy of the G3W-SUITE web-gis application with Docker and Docker compose .
 


### PR DESCRIPTION
### List of changes:

- add a short opening comment in the header of each **`Dockerfile`** in order to find out more easily the purpose of that file (to be checked carefully, because it could be that some of these have changed their purpose over time..)

- make use of shorter **names** for [workflow](https://github.com/g3w-suite/g3w-suite-docker/blob/604870c1fa486cc946a9abf567ef816a4e7303a5/.github/workflows) files (docker hub builds) in order to show a quicker description on badges added in the **`README.md`** file by https://github.com/g3w-suite/g3w-suite-docker/commit/0c6a228514f254e302d851bdd60edd729740e993, that is:
  - **BEFORE:** `CI to Docker hub for main G3W-SUITE image.` | `CI to Docker hub for dependencies image.`
  - **AFTER:**  `Build G3W-SUITE image` | `Build dependencies`