### PR TITLE
Add restart policy and internal network to elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,9 @@ services:
     volumes:
       - ${WEBGIS_DOCKER_SHARED_VOLUME}/esdata:/usr/share/elasticsearch/data
       #- esdata:/usr/share/elasticsearch/data
+    networks:
+      internal:
+    restart: always
 
   nginx:
     image: nginx
@@ -118,6 +121,7 @@ services:
     restart: always
     networks:
       internal:
+    restart: always
 
   # Letsencrypt certs
   certbot:


### PR DESCRIPTION
I'm wondering if there a reason not to add the networks internal etc. part?

Without it I cannot easily do the project indexing:
`docker-compose exec -T g3w-suite bash -c "cd /code/g3w-admin && python3 manage.py qes_indexer -v 2"`