### PR TITLE
Make Elastic Host configurable

### DIFF
--- a/config/g3w-suite/settings_docker.py
+++ b/config/g3w-suite/settings_docker.py
@@ -112,7 +112,7 @@ QDJANGO_SERVER_URL = 'http://localhost:8000'
 
 ELASTICSEARCH_DSL = {
     'default': {
-        'hosts': 'http://elasticsearch:9200',
+        'hosts': os.getenv('G3WSUITE_ELASTIC_HOST', 'http://elasticsearch:9200'),
         #'http_auth': ('username', 'password')
     }
 }


### PR DESCRIPTION
Add G3WSUITE_ELASTIC_HOST variable environment to facilitate use of the docker images in a Kubernetes environment

Closes: #