### PR TITLE
Build frontend in docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       - postgis
     volumes:
       - ${WEBGIS_DOCKER_SHARED_VOLUME}:/shared-volume
-      - ${WEBGIS_DOCKER_SHARED_VOLUME}/node_modules:/code/node_modules
       - ./config/g3w-suite/overrides/static:/code/static:ro
       - ./config/g3w-suite/overrides/templates:/code/templates:ro
       - ./config/g3w-suite/settings_docker.py:/code/g3w-admin/base/settings/local_settings.py

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -29,8 +29,6 @@ fi
 # Check Redis is started
 wait-for-it -h ${G3WSUITE_REDIS_HOST:-redis} -p ${G3WSUITE_REDIS_PORT:-6379} -t 30
 
-# Build the suite
-/code/ci_scripts/build_suite.sh
 # Setup once
 /code/ci_scripts/setup_suite.sh
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,3 +28,6 @@ pip3 install -r /code/g3w-admin/filemanager/requirements.txt
 # Qplotly
 pip3 install -r /code/g3w-admin/qplotly/requirements.txt
 
+# Build the suite
+mkdir /shared-volume
+/code/ci_scripts/build_suite.sh


### PR DESCRIPTION
Currently, the frontend is built when the container starts, which requires access to the npm registry from the production environment.

This PR moves the frontend build step to the docker build phase, so it is performed in the development and CI environments instead.

With this change, the Docker image can run in environments without access to the npm registry.

Here is a link to [build_suite.sh](https://github.com/g3w-suite/g3w-admin/blob/dev/ci_scripts/build_suite.sh)