### PR TITLE
Suppress xvfb warnings

### DIFF
--- a/scripts/docker-entrypoint-dev.sh
+++ b/scripts/docker-entrypoint-dev.sh
@@ -11,7 +11,7 @@ figlet -t "G3W-SUITE" && echo -e "v`git tag --sort=v:refname | tail -1 | sed 's/
 if [[  -f /tmp/.X99-lock ]]; then
   rm /tmp/.X99-lock
 fi
-Xvfb :99 -screen 0 640x480x24 -nolisten tcp &
+Xvfb :99 -screen 0 640x480x24 -nolisten tcp 2>/dev/null &
 
 export DISPLAY=:99
 export QGIS_SERVER_PARALLEL_RENDERING=1

--- a/scripts/docker-entrypoint-dev.sh
+++ b/scripts/docker-entrypoint-dev.sh
@@ -11,7 +11,10 @@ figlet -t "G3W-SUITE" && echo -e "v`git tag --sort=v:refname | tail -1 | sed 's/
 if [[  -f /tmp/.X99-lock ]]; then
   rm /tmp/.X99-lock
 fi
-Xvfb :99 -screen 0 640x480x24 -nolisten tcp 2>/dev/null &
+Xvfb :99 -screen 0 640x480x24 -nolisten tcp \
+  # HOTFIX for Ubuntu 24.04
+  2> >(sed '/The XKEYBOARD keymap compiler (xkbcomp) reports:/d;/Could not resolve keysym XF86/d;/Errors from xkbcomp are not fatal to the X server/d' >&2) \
+  &
 
 export DISPLAY=:99
 export QGIS_SERVER_PARALLEL_RENDERING=1

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -9,7 +9,10 @@ figlet -t "G3W-SUITE Docker by Gis3w"
 if [[  -f /tmp/.X99-lock ]]; then
   rm /tmp/.X99-lock
 fi
-Xvfb :99 -screen 0 640x480x24 -nolisten tcp 2>/dev/null &
+Xvfb :99 -screen 0 640x480x24 -nolisten tcp \
+  # HOTFIX for Ubuntu 24.04
+  2> >(sed '/The XKEYBOARD keymap compiler (xkbcomp) reports:/d;/Could not resolve keysym XF86/d;/Errors from xkbcomp are not fatal to the X server/d' >&2) \
+  &
 export DISPLAY=:99
 export QGIS_SERVER_PARALLEL_RENDERING=1
 # Start

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -9,7 +9,7 @@ figlet -t "G3W-SUITE Docker by Gis3w"
 if [[  -f /tmp/.X99-lock ]]; then
   rm /tmp/.X99-lock
 fi
-Xvfb :99 -screen 0 640x480x24 -nolisten tcp &
+Xvfb :99 -screen 0 640x480x24 -nolisten tcp 2>/dev/null &
 export DISPLAY=:99
 export QGIS_SERVER_PARALLEL_RENDERING=1
 # Start


### PR DESCRIPTION
Prevent these lines from polluting your server logs:

```sh
The XKEYBOARD keymap compiler (xkbcomp) reports:

> Warning:          Could not resolve keysym XF86CameraAccessEnable
> Warning:          Could not resolve keysym XF86CameraAccessDisable
> Warning:          Could not resolve keysym XF86CameraAccessToggle
> Warning:          Could not resolve keysym XF86NextElement
> Warning:          Could not resolve keysym XF86PreviousElement
> Warning:          Could not resolve keysym XF86AutopilotEngageToggle
> Warning:          Could not resolve keysym XF86MarkWaypoint
> Warning:          Could not resolve keysym XF86Sos
> Warning:          Could not resolve keysym XF86NavChart
> Warning:          Could not resolve keysym XF86FishingChart
> Warning:          Could not resolve keysym XF86SingleRangeRadar
> Warning:          Could not resolve keysym XF86DualRangeRadar
> Warning:          Could not resolve keysym XF86RadarOverlay
> Warning:          Could not resolve keysym XF86TraditionalSonar
> Warning:          Could not resolve keysym XF86ClearvuSonar
> Warning:          Could not resolve keysym XF86SidevuSonar
> Warning:          Could not resolve keysym XF86NavInfo

Errors from xkbcomp are not fatal to the X server
```