### PR TITLE
Update SSL configuration URLs in renew-ssl.sh to use the correct paths

### DIFF
--- a/scripts/makefile/renew-ssl.sh
+++ b/scripts/makefile/renew-ssl.sh
@@ -16,8 +16,8 @@ fi
 
 certs_folder="${WEBGIS_DOCKER_SHARED_VOLUME}/certs/letsencrypt"
 acme_folder="${WEBGIS_DOCKER_SHARED_VOLUME}/var/www/.well-known"
-default_ssl_conf="https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf"
-default_ssl_pem="https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem"
+default_ssl_conf="https://raw.githubusercontent.com/certbot/certbot/refs/heads/main/certbot/src/certbot/_internal/plugins/nginx/tls_configs/options-ssl-nginx.conf"
+default_ssl_pem="https://raw.githubusercontent.com/certbot/certbot/refs/heads/main/certbot/src/certbot/ssl-dhparams.pem"
 domain="$WEBGIS_PUBLIC_HOSTNAME"
 
 # STEP 1


### PR DESCRIPTION
This pull request updates the URLs used to fetch SSL configuration files in the `renew-ssl.sh` script to reflect the latest locations in the Certbot repository. This ensures that the script uses the most up-to-date SSL configurations.

**Dependency updates:**

* Updated the `default_ssl_conf` and `default_ssl_pem` variables in `renew-ssl.sh` to point to the new file paths in the Certbot repository, using the `main` branch and updated directory structure.